### PR TITLE
creating directories in a portable way

### DIFF
--- a/lua/git/objects.lua
+++ b/lua/git/objects.lua
@@ -1,3 +1,5 @@
+local util = require 'git.util'
+
 local assert, next, io, print, os, type, string =
 	assert, next, io, print, os, type, string
 local join_path = git.util.join_path
@@ -64,10 +66,12 @@ function Tree:walk(func, path)
 end
 
 function Tree:checkoutTo(path)
-	os.execute(string.format('mkdir -p %q', path))
+	util.make_dir(path)
+	--os.execute(string.format('mkdir -p %q', path))
 	self:walk(function (entry, entry_path, type)
 		if type == 'tree' then
-			os.execute(string.format('mkdir -p %q', entry_path))
+			util.make_dir(entry_path)
+			--os.execute(string.format('mkdir -p %q', entry_path))
 		else
 			local out = assert(io.open(entry_path, 'w'))
 			out:write(entry:content())

--- a/lua/git/repo.lua
+++ b/lua/git/repo.lua
@@ -54,7 +54,8 @@ function Repo:store_object(data, len, type)
 	local sha = readable_sha(object_sha(data, len, type))
 	local dir = sha:sub(1,2)
 	local file = sha:sub(3)
-	os.execute('mkdir -p '..join_path(self.dir, 'objects', dir))
+	util.make_dir(join_path(self.dir, 'objects', dir))
+	--os.execute('mkdir -p '..join_path(self.dir, 'objects', dir))
 	local path = join_path(self.dir, 'objects', dir, file)
 	local fo = assert(io.open(path, 'w'))
 	local header = type .. ' ' .. len .. '\0'
@@ -155,7 +156,8 @@ function create(dir)
 		dir = join_path(dir, '.git')
 	end
 	
-	os.execute('mkdir -p '..dir)
+	util.make_dir(dir)
+	-- os.execute('mkdir -p '..dir)
 
 	local refs = {}
 	local packs = {}

--- a/lua/git/util.lua
+++ b/lua/git/util.lua
@@ -66,7 +66,7 @@ local function parent_dir(path)
     if dir == "" then
         return nil
     else
-        return dir
+        return remove_trailing(dir)
     end
 end
 

--- a/lua/git/util.lua
+++ b/lua/git/util.lua
@@ -1,3 +1,4 @@
+local lfs = require 'lfs'
 local core = require 'git.core'
 local deflate = core.deflate
 local inflate = core.inflate
@@ -18,6 +19,68 @@ function join_path(...)
 		args[i] = args[i]:gsub(dirsep..'?$', '')
 	end
 	return table.concat(args, dirsep, 1, n)
+end
+
+-- Return the path with the all occurences of '/.' or '\.' (representing
+-- the current directory) removed.
+local function remove_curr_dir_dots(path)
+    while path:match(dirsep .. "%." .. dirsep) do             -- match("/%./")
+        path = path:gsub(dirsep .. "%." .. dirsep, dirsep)    -- gsub("/%./", "/")
+    end
+    return path:gsub(dirsep .. "%.$", "")                     -- gsub("/%.$", "")
+end
+
+-- Return whether the path is a root.
+local function is_root(path)
+    return path:find("^[%u%U.]?:?[/\\]$")
+end
+
+-- Return the path with the unnecessary trailing separator removed.
+local function remove_trailing(path)
+    if path:sub(-1) == dirsep and not is_root(path) then path = path:sub(1,-2) end
+    return path
+end
+
+-- Extract file or directory name from its path.
+local function extract_name(path)
+    if is_root(path) then return path end
+
+    path = remove_trailing(path)
+    path = path:gsub("^.*" .. dirsep, "")
+    return path
+end
+
+-- Return the string 'str', with all magic (pattern) characters escaped.
+local function escape_magic(str)
+    local escaped = str:gsub('[%-%.%+%[%]%(%)%^%%%?%*%^%$]','%%%1')
+    return escaped
+end
+
+-- Return parent directory of the 'path' or nil if there's no parent directory.
+-- If 'path' is a path to file, return the directory the file is in.
+local function parent_dir(path)
+    path = remove_curr_dir_dots(path)
+    path = remove_trailing(path)
+
+    local dir = path:gsub(escape_magic(extract_name(path)) .. "$", "")
+    if dir == "" then
+        return nil
+    else
+        return dir
+    end
+end
+
+-- Make a new directory, making also all of its parent directories that doesn't exist.
+function make_dir(path)
+    if lfs.attributes(path) then
+        return true
+    else
+        local par_dir = parent_dir(path)
+        if par_dir then
+            assert(make_dir(par_dir))
+        end
+        return lfs.mkdir(path)
+    end
 end
 
 -- decompress the file and return a handle to temporary uncompressed file


### PR DESCRIPTION
The command `mkdir -p DIR` isn't available under Windows, so I copied a function [`util.make_dir()`](https://github.com/mnicky/lua-git/blob/master/lua/git/util.lua#L73) that I use in luadist-git and replaced all calls to `mkdir` with it.

<br>
Creating of directories seems to work under Windows now, however, I still get errors when trying to fetch some repository (under Windows). I reported them in issue [#3](https://github.com/mkottman/lua-git/issues/3).
