### PR TITLE
Directory to which refs should be written doesn't exist on Windows

### DIFF
--- a/dist.info
+++ b/dist.info
@@ -1,7 +1,7 @@
 --- This file is part of LuaDist project
 
 name = "lua-git"
-version = "0.2"
+version = "0.3"
 
 desc = "A library to access Git repositories and its objects (files, commits) in Lua"
 author = "Michal Kottman"

--- a/lua/git/protocol.lua
+++ b/lua/git/protocol.lua
@@ -5,6 +5,9 @@ local lfs = require 'lfs'
 local Repo = git.repo.Repo
 local Pack = git.pack.Pack
 local join_path = git.util.join_path
+local parent_dir = git.util.parent_dir
+local make_dir = git.util.make_dir
+local correct_separators = git.util.correct_separators
 
 local assert, error, getmetatable, io, os, pairs, print, require, string, tonumber =
 	assert, error, getmetatable, io, os, pairs, print, require, string, tonumber
@@ -116,7 +119,9 @@ local function git_fetch(host, path, repo, head, supress_progress)
 		pack:unpack(repo)
 		repo.isShallow = true
 		if wantedSha then
-			local f = assert(io.open(repo.dir .. "/" .. head, "w"))
+			local headfile = correct_separators(join_path(repo.dir, head))
+			assert(make_dir(parent_dir(headfile)))
+			local f = assert(io.open(headfile, 'wb'))
 			f:write(wantedSha)
 			f:close()
 		end

--- a/lua/git/util.lua
+++ b/lua/git/util.lua
@@ -10,6 +10,11 @@ local BUF_SIZE = 4096
 
 local dirsep = package.config:sub(1,1)
 
+-- replaces '/' path separators on Windows with the correct ones ('\\')
+function correct_separators(path)
+	return path:gsub('/', dirsep)
+end
+
 -- joins several path components into a single path, uses system-specific directory
 -- separator, cleans input, i.e. join_path('a/', 'b', 'c/') => 'a/b/c'
 function join_path(...)
@@ -58,7 +63,7 @@ end
 
 -- Return parent directory of the 'path' or nil if there's no parent directory.
 -- If 'path' is a path to file, return the directory the file is in.
-local function parent_dir(path)
+function parent_dir(path)
     path = remove_curr_dir_dots(path)
     path = remove_trailing(path)
 

--- a/test_fetch-win.lua
+++ b/test_fetch-win.lua
@@ -1,0 +1,8 @@
+require 'git'
+
+os.execute('rd /S /Q C:\\tmp\\test.git')
+os.execute('rd /S /Q C:\\tmp\\extracted')
+
+R = git.repo.create('C:\\tmp\\test.git')
+local pack, sha = git.protocol.fetch('git://github.com/mkottman/lua-git.git', R, 'refs/heads/master')
+R:checkout(sha, 'C:\\tmp\\extracted')


### PR DESCRIPTION
When running [this test](https://github.com/mnicky/lua-git/blob/10220dc4e1615325d0e899c27ff10e54f1bab9e5/test_fetch-win.lua) on Windows, I was getting:

```
C:\luadist\_install\>bin\lua.exe ..\test_fetch.lua
Counting objects: 32, done.
Compressing objects: 100% (32/32), done.
Total 32 (delta 4), reused 23 (delta 0)
bin\lua.exe: ..._install\bin\..\lib\lua\git\protocol.lua:119: C:\tmp\test.git/refs/heads/master: No such file or directory
stack traceback:
        [C]: in function 'assert'
        ..._install\bin\..\lib\lua\git\protocol.lua:119: in function 'git_fetch'
        ..._install\bin\..\lib\lua\git\protocol.lua:132: in function 'fetch'
        ..\..\..\test_fetch.lua:8: in main chunk
        [C]: ?

```

The problem is caused probably by [c990394](https://github.com/mkottman/lua-git/commit/c990394949199192f7b5dee9475c8aa8c2542992) where the path separator `/` is used and the directory (in which the file that's about to be opened should be located) isn't created before. I don't know why the latter doesn't cause error also on Linux though...

I'm also adding the Windows test file for future use...
